### PR TITLE
Update gmi.R

### DIFF
--- a/R/gmi.R
+++ b/R/gmi.R
@@ -9,20 +9,33 @@
 #' @param data DataFrame object with column names "id", "time", and "gl",
 #' or numeric vector of glucose values.
 #'
+#' updated description of return.
 #' @return If a data.frame object is passed, then a tibble object with
-#' two columns: subject id and corresponding GMI is returned. If a vector of glucose
-#' values is passed, then a tibble object with just the GMI value is returned.
+#' three columns: subject id, corresponding GMI and unit of glucose measure 
+#' is returned. If a vector of glucose values is passed, then a tibble object 
+#' with the GMI value and unit of glucose measure is returned.
 #' as.numeric() can be wrapped around the latter to output just a numeric value.
 #'
 #' @export
 #'
+#' updated description of return and GMI calculation
 #' @details
-#' A tibble object with 1 row for each subject, a column for subject id and
-#' a column for GMI values is returned. NA glucose values are
-#' omitted from the calculation of the GMI.
+#' A tibble object with 1 row for each subject, a column for subject id, 
+#' a column for GMI values, and unit of glucose measure is returned.
+#' NA glucose values are omitted from the calculation of the GMI.
 #'
-#' GMI score is calculated by \eqn{3.31 + (.02392*mean(G))}
+#' GMI score is calculated depending on the metric that glucose is recorded in. 
+#' The glucose unit (mg/dL or mmol/L) must be specified as part of the function. 
+#' GMI is calculated by either: 
+#' \eqn{3.31 + (.02392*mean(G))}
 #' where G is the vector of Glucose Measurements (mg/dL).
+#' 
+#' Or 
+#' 
+#' \eqn{12.71 + (4.70587*mean(G))}
+#' where G is the vector of Glucose Measurements (mmol/L). 
+#' 
+#'
 #'
 #' @references
 #' Bergenstal (2018) Glucose Management Indicator (GMI): A New Term for
@@ -32,27 +45,42 @@
 #'
 #' @examples
 #'
+#' #changes propose using specifying the unit the data is recorded in the function.
 #' data(example_data_1_subject)
-#' gmi(example_data_1_subject)
+#' gmi(example_data_1_subject, "mg")
 #'
 #' data(example_data_5_subject)
-#' gmi(example_data_5_subject)
+#' gmi(example_data_5_subject, "mg")
 #'
 
-gmi <- function(data){
+# change to function specifies the unit data is recorded in to specify approach 
+# to calculating GMI 
+gmi <- function(data, unit){ # change requires unit of glucose recorded to be specified
   gl = id = NULL
   rm(list = c("gl", "id"))
   data = check_data_columns(data)
   is_vector = attr(data, "is_vector")
-
-  out = data %>%
-    dplyr::group_by(id) %>%
-    dplyr::summarise(
-      GMI = 3.31 + (.02392*mean(gl, na.rm = TRUE) )
-    )
+  
+  if (unit == "mg") {  # calculation of gmi baed on recorded units in mg
+    out = data %>%
+      dplyr::group_by(id) %>%
+      dplyr::summarise(
+        GMI = 3.31 + (.02392*mean(gl, na.rm = TRUE) )
+      )
+  } else if (unit == "mmol") { # calculation of gmi baed on recorded units in mmol
+    out = data %>%
+      dplyr::group_by(id) %>%
+      dplyr::summarise(
+        GMI = 12.71 + (4.70587*mean(gl, na.rm = TRUE) )
+      )
+  } else {
+# added error notice of failure to specify unit
+    stop("Invalid unit specified. Use 'mg' or 'mmol' to specify the unit glucose is recorded in.")
+  }
+# output now specifies the unit that glucose is recorded in.   
+  out$unit = unit
   if (is_vector) {
     out$id = NULL
   }
   return(out)
 }
-


### PR DESCRIPTION
Please see modifications to the calculation of GMI based on the metric 'mg' or 'mmol' that glucose values are recorded in. This differs to the current approach which adjusts values in mmol/l to mg/dL prior to calculation. Values are reported based on the metric unit.